### PR TITLE
bug fix: show correct value (brightness) on lovelace light card

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1046,9 +1046,11 @@ class WebServer {
                         this.adapter.setForeignState(entity.context.STATE.setId, true, false, {user}, () => {
                             // If dimmer level set
                             if (data.service_data.brightness_pct !== undefined) {
+                                entity.attributes.brightness = data.service_data.brightness_pct * 255 / entity.attributes.iob_max;
                                 this.adapter.setForeignState(command.setId, data.service_data.brightness_pct, false, {user}, err =>
                                     err ? reject(err) : resolve());
                             } else {
+                                entity.attributes.brightness = command.on * 255 / entity.attributes.iob_max;
                                 this.adapter.setForeignState(command.setId, command.on, false, {user}, err =>
                                     err ? reject(err) : resolve());
                             }
@@ -1056,6 +1058,7 @@ class WebServer {
                     } else
                     // If dimmer level set
                     if (data.service_data.brightness_pct !== undefined) {
+                        entity.attributes.brightness = data.service_data.brightness_pct * 255 / entity.attributes.iob_max;
                         this.adapter.setForeignState(command.setId, data.service_data.brightness_pct, false, {user}, err =>
                             err ? reject(err) : resolve());
                     } else {
@@ -1065,6 +1068,7 @@ class WebServer {
             } else
             // If dimmer level set
             if (data.service_data.brightness_pct !== undefined) {
+                entity.attributes.brightness = data.service_data.brightness_pct * 255 / entity.attributes.iob_max;
                 this.adapter.setForeignState(command.setId, data.service_data.brightness_pct, false, {user}, err =>
                     err ? reject(err) : resolve());
             } else {
@@ -1075,6 +1079,8 @@ class WebServer {
 
     _processDimmer(id, control, name, room, func, _obj) {
         const entity = this._processCommon(id, name, room, func, _obj, 'light');
+
+        entity.attributes.iob_max = _obj.common.max;
 
         let state = control.states.find(s => s.id && s.name === 'ON_SET');
         entity.context.STATE = {setId: null, getId: null};
@@ -1099,6 +1105,7 @@ class WebServer {
         state = control.states.find(s => s.id && s.name === 'SET');
         if (state && state.id) {
             getDimmer = getDimmer || state.id;
+            entity.attributes.brightness = state.val;
             entity.context.ATTRIBUTES = [{attribute: 'brightness', getId: getDimmer}];
             entity.context.COMMANDS = [{
                 service: 'turn_on',
@@ -1108,6 +1115,7 @@ class WebServer {
             }];
             this._addID2entity(state.id, entity);
         } else if (getDimmer) {
+            entity.attributes.brightness = state.val;
             entity.context.ATTRIBUTES = [{attribute: 'brightness', getId: getDimmer}];
             this._addID2entity(state.id, entity);
         }
@@ -1322,20 +1330,29 @@ class WebServer {
 
             if (entityType === 'light') {
                 if (obj.common.type === 'number') {
-                    entity.context.COMMANDS = [{
-                        service: 'turn_on',
-                        setId: id,
-                        on: obj.common.max || 100,
-                        parseCommand: this._parseCommandDimmer.bind(this)
-                    },
-                    {
-                        service: 'turn_off',
-                        setId: id,
-                        off: obj.common.min || 0,
-                        parseCommand: (entity, command, data, user) =>
-                            new Promise((resolve, reject) =>
-                                this.adapter.setForeignState(command.setId, command.off, false, {user}, err => err ? reject(err) : resolve()))
-                    }];
+                    entity.attributes.iob_max = obj.common.max;
+
+                    this.adapter.getForeignState
+
+                    this.adapter.getForeignState(id, (err, state) => {
+                        entity.attributes.brightness = state.val * 255 / entity.attributes.iob_max;
+                        entity.context.COMMANDS = [{
+                            service: 'turn_on',
+                            setId: id,
+                            on: obj.common.max || 100,
+                            parseCommand: this._parseCommandDimmer.bind(this)
+                        },
+                        {
+                            service: 'turn_off',
+                            setId: id,
+                            off: obj.common.min || 0,
+                            parseCommand: (entity, command, data, user) =>
+                                new Promise((resolve, reject) =>
+                                    this.adapter.setForeignState(command.setId, command.off, false, {user}, err => err ? reject(err) : resolve()))
+                        }];
+                    });
+
+
                 }
             } else if (entityType === 'camera') {
                 entity.context.STATE = {getValue: 'on'};
@@ -1676,6 +1693,10 @@ class WebServer {
                         if (entity.context.STATE.getParser) {
                             entity.context.STATE.getParser(entity, 'state', state);
                         } else {
+                            if (entity.context.type === 'light' && typeof(state.val) === 'number'){
+                                // is dimmer
+                                entity.attributes.brightness = state.val * 255 / entity.attributes.iob_max;
+                            }
                             entity.state = this._iobState2EntityState(id, state.val);
                         }
                     } else


### PR DESCRIPTION
Because the light card has no max value attribute (is hardcoded 255) we need a to add a max attribute taken from the object to calculate the correct value.

This bug fix works only for manual created entities at the moment.
For auto detect we need a max value, but dont know how the detection works in detail